### PR TITLE
Add consistent mobile navigation across pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,18 @@
     .skip-link { position:absolute; left:-999px; top:auto; width:1px; height:1px; overflow:hidden; }
     .skip-link:focus { position: static; width: auto; height: auto; padding: .5rem .75rem; background: var(--focus); color: white; border-radius: .5rem; }
 
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
     /* Header */
     header {
       position: sticky; top: 0; z-index: 10; background: rgba(255,255,255,.85);
@@ -64,12 +76,12 @@
     .nav-links a:hover { background: var(--bg-soft); color: var(--ink); text-decoration: none; }
 
     .hamburger { display: none; background: transparent; border: 1px solid var(--border); padding: .5rem .6rem; border-radius: .6rem; }
+    .mobile-menu { display: none; border-top: 1px solid var(--border); }
 
     /* Mobile menu */
     @media (max-width: 840px) {
       .nav-links { display: none; }
       .hamburger { display: inline-flex; align-items: center; gap: .5rem; }
-      .mobile-menu { display: none; border-top: 1px solid var(--border); }
       .mobile-menu.open { display: block; }
       .mobile-menu a { display: block; padding: .9rem 0; border-bottom: 1px solid var(--border); color: var(--muted-ink); }
       .mobile-menu a:hover { background: var(--bg-soft); color: var(--ink); text-decoration: none; }
@@ -122,27 +134,36 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header>
     <div class="container nav" role="navigation" aria-label="Primary">
-      <a class="logo" href="#" aria-label="Spring Global home">
+      <a class="logo" href="#home" aria-label="Spring Global home">
   <img src="assets/logo.png" alt="" class="logo-img" />
   <span class="brand">Spring Global</span>
 </a>
       <nav class="nav-links" aria-label="Top">
         <a href="#home">Home</a>
-       <a href="terms.html">Terms of Service</a>
-       <a href="privacy.html">Privacy Policy</a>
-       <a href="opt-out.html">Opt-Out</a>
-       <a href="#contact">Contact</a>
+        <a href="terms.html">Terms of Service</a>
+        <a href="privacy.html">Privacy Policy</a>
+        <a href="opt-out.html">Opt-Out</a>
+        <a href="#contact">Contact</a>
       </nav>
       <button class="hamburger" aria-controls="mobile-menu" aria-expanded="false" id="menuBtn">
         <span aria-hidden="true">☰</span>
         <span class="sr-only">Menu</span>
       </button>
     </div>
+    <nav id="mobile-menu" class="mobile-menu" aria-label="Mobile">
+      <div class="container">
+        <a href="#home">Home</a>
+        <a href="terms.html">Terms of Service</a>
+        <a href="privacy.html">Privacy Policy</a>
+        <a href="opt-out.html">Opt-Out</a>
+        <a href="#contact">Contact</a>
+      </div>
+    </nav>
   </header>
 
   <main id="main">
     <!-- Hero -->
-    <section class="hero">
+    <section class="hero" id="home">
       <div class="container">
         <h1>
           Transforming diabetes care
@@ -246,7 +267,7 @@
             <textarea name="message" rows="5" required></textarea>
           </label>
           <div class="row" style="margin-top:.8rem; align-items:center; justify-content:space-between;">
-            <label class="small"><input type="checkbox" required /> I agree to the <a href="#terms">Terms of Service</a>.</label>
+            <label class="small"><input type="checkbox" required /> I agree to the <a href="terms.html">Terms of Service</a>.</label>
             <button class="cta" type="submit">Send</button>
           </div>
         </form>
@@ -265,9 +286,9 @@
       </div>
       <nav class="small" aria-label="Footer">
         <a href="#about">About</a> ·
-        <a href="#tos">Terms</a> ·
-        <a href="#privacy">Privacy</a> ·
-        <a href="#optout">Opt-Out</a> ·
+        <a href="terms.html">Terms</a> ·
+        <a href="privacy.html">Privacy</a> ·
+        <a href="opt-out.html">Opt-Out</a> ·
         <a href="#contact">Contact</a>
       </nav>
     </div>
@@ -278,8 +299,14 @@
     const menuBtn = document.getElementById('menuBtn');
     const mobile = document.getElementById('mobile-menu');
     menuBtn?.addEventListener('click', () => {
-      const open = mobile.classList.toggle('open');
-      menuBtn.setAttribute('aria-expanded', String(open));
+      const open = mobile?.classList.toggle('open');
+      menuBtn.setAttribute('aria-expanded', String(Boolean(open)));
+    });
+    mobile?.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        mobile.classList.remove('open');
+        menuBtn?.setAttribute('aria-expanded', 'false');
+      });
     });
     // Current year
     document.getElementById('year').textContent = new Date().getFullYear();

--- a/opt-out.html
+++ b/opt-out.html
@@ -31,6 +31,26 @@
     .nav-links { display: flex; gap: 1rem; align-items: center; }
     .nav-links a { padding: .5rem .6rem; border-radius: .6rem; color: var(--muted-ink); font-weight: 500; }
     .nav-links a:hover { background: var(--bg-soft); color: var(--ink); text-decoration: none; }
+    .hamburger { display: none; background: transparent; border: 1px solid var(--border); padding: .5rem .6rem; border-radius: .6rem; }
+    .mobile-menu { display: none; border-top: 1px solid var(--border); }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+    @media (max-width: 840px) {
+      .nav-links { display: none; }
+      .hamburger { display: inline-flex; align-items: center; gap: .5rem; }
+      .mobile-menu.open { display: block; }
+      .mobile-menu a { display: block; padding: .9rem 0; border-bottom: 1px solid var(--border); color: var(--muted-ink); }
+      .mobile-menu a:hover { background: var(--bg-soft); color: var(--ink); text-decoration: none; }
+    }
     main { padding: 2rem 0; }
     h1 { font-size: clamp(1.6rem, 2.2vw + 1rem, 2.4rem); line-height: 1.15; margin: 1rem 0; }
     h2 { margin-top: 2rem; }
@@ -43,7 +63,7 @@
 <body>
   <header>
     <div class="container nav" role="navigation" aria-label="Primary">
-      <a class="logo" href="index.html" aria-label="Spring Global home">
+      <a class="logo" href="index.html#home" aria-label="Spring Global home">
         <span class="logo-mark" aria-hidden="true"></span>
         <span class="brand">Spring Global</span>
       </a>
@@ -54,7 +74,20 @@
         <a href="opt-out.html">Opt-Out</a>
         <a href="index.html#contact">Contact</a>
       </nav>
+      <button class="hamburger" aria-controls="mobile-menu" aria-expanded="false" id="menuBtn">
+        <span aria-hidden="true">☰</span>
+        <span class="sr-only">Menu</span>
+      </button>
     </div>
+    <nav id="mobile-menu" class="mobile-menu" aria-label="Mobile">
+      <div class="container">
+        <a href="index.html#home">Home</a>
+        <a href="terms.html">Terms of Service</a>
+        <a href="privacy.html">Privacy Policy</a>
+        <a href="opt-out.html">Opt-Out</a>
+        <a href="index.html#contact">Contact</a>
+      </div>
+    </nav>
   </header>
   <main>
     <div class="container">
@@ -135,6 +168,23 @@
       <div class="small">© <span id="year"></span> Spring Global. All rights reserved.</div>
     </div>
   </footer>
-  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  <script>
+    const yearEl = document.getElementById('year');
+    if (yearEl) {
+      yearEl.textContent = new Date().getFullYear();
+    }
+    const menuBtn = document.getElementById('menuBtn');
+    const mobile = document.getElementById('mobile-menu');
+    menuBtn?.addEventListener('click', () => {
+      const open = mobile?.classList.toggle('open');
+      menuBtn.setAttribute('aria-expanded', String(Boolean(open)));
+    });
+    mobile?.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        mobile.classList.remove('open');
+        menuBtn?.setAttribute('aria-expanded', 'false');
+      });
+    });
+  </script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -31,6 +31,26 @@
     .nav-links { display: flex; gap: 1rem; align-items: center; }
     .nav-links a { padding: .5rem .6rem; border-radius: .6rem; color: var(--muted-ink); font-weight: 500; }
     .nav-links a:hover { background: var(--bg-soft); color: var(--ink); text-decoration: none; }
+    .hamburger { display: none; background: transparent; border: 1px solid var(--border); padding: .5rem .6rem; border-radius: .6rem; }
+    .mobile-menu { display: none; border-top: 1px solid var(--border); }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+    @media (max-width: 840px) {
+      .nav-links { display: none; }
+      .hamburger { display: inline-flex; align-items: center; gap: .5rem; }
+      .mobile-menu.open { display: block; }
+      .mobile-menu a { display: block; padding: .9rem 0; border-bottom: 1px solid var(--border); color: var(--muted-ink); }
+      .mobile-menu a:hover { background: var(--bg-soft); color: var(--ink); text-decoration: none; }
+    }
     main { padding: 2rem 0; }
     h1 { font-size: clamp(1.6rem, 2.2vw + 1rem, 2.4rem); line-height: 1.15; margin: 1rem 0; }
     h2 { margin-top: 2rem; }
@@ -43,7 +63,7 @@
 <body>
   <header>
     <div class="container nav" role="navigation" aria-label="Primary">
-      <a class="logo" href="index.html" aria-label="Spring Global home">
+      <a class="logo" href="index.html#home" aria-label="Spring Global home">
         <span class="logo-mark" aria-hidden="true"></span>
         <span class="brand">Spring Global</span>
       </a>
@@ -54,7 +74,20 @@
         <a href="opt-out.html">Opt-Out</a>
         <a href="index.html#contact">Contact</a>
       </nav>
+      <button class="hamburger" aria-controls="mobile-menu" aria-expanded="false" id="menuBtn">
+        <span aria-hidden="true">☰</span>
+        <span class="sr-only">Menu</span>
+      </button>
     </div>
+    <nav id="mobile-menu" class="mobile-menu" aria-label="Mobile">
+      <div class="container">
+        <a href="index.html#home">Home</a>
+        <a href="terms.html">Terms of Service</a>
+        <a href="privacy.html">Privacy Policy</a>
+        <a href="opt-out.html">Opt-Out</a>
+        <a href="index.html#contact">Contact</a>
+      </div>
+    </nav>
   </header>
   <main>
     <div class="container">
@@ -101,6 +134,23 @@
       <div class="small">© <span id="year"></span> Spring Global. All rights reserved.</div>
     </div>
   </footer>
-  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  <script>
+    const yearEl = document.getElementById('year');
+    if (yearEl) {
+      yearEl.textContent = new Date().getFullYear();
+    }
+    const menuBtn = document.getElementById('menuBtn');
+    const mobile = document.getElementById('mobile-menu');
+    menuBtn?.addEventListener('click', () => {
+      const open = mobile?.classList.toggle('open');
+      menuBtn.setAttribute('aria-expanded', String(Boolean(open)));
+    });
+    mobile?.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        mobile.classList.remove('open');
+        menuBtn?.setAttribute('aria-expanded', 'false');
+      });
+    });
+  </script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -31,6 +31,26 @@
     .nav-links { display: flex; gap: 1rem; align-items: center; }
     .nav-links a { padding: .5rem .6rem; border-radius: .6rem; color: var(--muted-ink); font-weight: 500; }
     .nav-links a:hover { background: var(--bg-soft); color: var(--ink); text-decoration: none; }
+    .hamburger { display: none; background: transparent; border: 1px solid var(--border); padding: .5rem .6rem; border-radius: .6rem; }
+    .mobile-menu { display: none; border-top: 1px solid var(--border); }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+    @media (max-width: 840px) {
+      .nav-links { display: none; }
+      .hamburger { display: inline-flex; align-items: center; gap: .5rem; }
+      .mobile-menu.open { display: block; }
+      .mobile-menu a { display: block; padding: .9rem 0; border-bottom: 1px solid var(--border); color: var(--muted-ink); }
+      .mobile-menu a:hover { background: var(--bg-soft); color: var(--ink); text-decoration: none; }
+    }
     main { padding: 2rem 0; }
     h1 { font-size: clamp(1.6rem, 2.2vw + 1rem, 2.4rem); line-height: 1.15; margin: 1rem 0; }
     h2 { margin-top: 2rem; }
@@ -43,7 +63,7 @@
 <body>
   <header>
     <div class="container nav" role="navigation" aria-label="Primary">
-      <a class="logo" href="index.html" aria-label="Spring Global home">
+      <a class="logo" href="index.html#home" aria-label="Spring Global home">
         <span class="logo-mark" aria-hidden="true"></span>
         <span class="brand">Spring Global</span>
       </a>
@@ -54,7 +74,20 @@
         <a href="opt-out.html">Opt-Out</a>
         <a href="index.html#contact">Contact</a>
       </nav>
+      <button class="hamburger" aria-controls="mobile-menu" aria-expanded="false" id="menuBtn">
+        <span aria-hidden="true">☰</span>
+        <span class="sr-only">Menu</span>
+      </button>
     </div>
+    <nav id="mobile-menu" class="mobile-menu" aria-label="Mobile">
+      <div class="container">
+        <a href="index.html#home">Home</a>
+        <a href="terms.html">Terms of Service</a>
+        <a href="privacy.html">Privacy Policy</a>
+        <a href="opt-out.html">Opt-Out</a>
+        <a href="index.html#contact">Contact</a>
+      </div>
+    </nav>
   </header>
   <main>
     <div class="container">
@@ -95,6 +128,23 @@
       <div class="small">© <span id="year"></span> Spring Global. All rights reserved.</div>
     </div>
   </footer>
-  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  <script>
+    const yearEl = document.getElementById('year');
+    if (yearEl) {
+      yearEl.textContent = new Date().getFullYear();
+    }
+    const menuBtn = document.getElementById('menuBtn');
+    const mobile = document.getElementById('mobile-menu');
+    menuBtn?.addEventListener('click', () => {
+      const open = mobile?.classList.toggle('open');
+      menuBtn.setAttribute('aria-expanded', String(Boolean(open)));
+    });
+    mobile?.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        mobile.classList.remove('open');
+        menuBtn?.setAttribute('aria-expanded', 'false');
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a skip link helper class and mobile navigation markup to the landing page
- update the contact form and footer links to reference the legal pages directly
- mirror the responsive navigation and script across the privacy, terms, and opt-out pages for consistency

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68cc5a3f46e08321b10d619a07c0e4f0